### PR TITLE
Updated TAC Agenda Template 

### DIFF
--- a/meeting-minutes/0000-template.md
+++ b/meeting-minutes/0000-template.md
@@ -5,43 +5,71 @@ parent: Meeting Minutes
 grand_parent: PQCA TAC
 nav_exclude: true
 ---
-<mark>_Copy this template to the subdirectory for the current year and name the file `YYYY-MM-DD-TAC-meeting-record.md` (e.g., `2023-02-02-TOC-meeting-record.md`). Update the information above to change the `title` (e.g., `2023-02-16 TOC Meeting Record`, the `parent` to `YYYY` (e.g., 2023), the `grand_parent` to `Meeting Minutes`, and remove the `nav_exclude` line. Update the links below to reflect the appropriate image location (e.g., `../images/`). Text between `<mark></mark>` are instructions. Please remove when section has been completed._
+<mark>_Copy this template to the subdirectory for the current year and name the file `YYYY-MM-DD-TAC-meeting-record.md` (e.g., `2023-02-02-TAC-meeting-record.md`). Update the information above to change the `title` (e.g., `2023-02-16 TAC Meeting Record`, the `parent` to `YYYY` (e.g., 2023), the `grand_parent` to `Meeting Minutes`, and remove the `nav_exclude` line. Update the links below to reflect the appropriate image location (e.g., `../images/`). Text between `<mark></mark>` are instructions. Please remove when section has been completed._
 </mark>
 
+# Post-Quantum Cryptography Alliance - Technical Advisory Council (TAC) Meeting DD Month, 20YY
+* [Join the meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/98559442147?password=5e9d28b7-97d4-4628-9087-5f359dbf3d80)
+* Recordings are available on your [Open Profile page](https://openprofile.dev/my-meetings) under Past Meetings
+* [PQCA Meeting Calendar](https://pqca.org/calendar/)
+* [Discord Server](https://discord.gg/pqca)
 
-# Announcements
-* <mark>_Put any announcements. Upcoming events, for example_
+## Antitrust Policy Notice
+Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws.
+
+Examples of types of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation Antitrust Policy available at [linuxfoundation.org/antitrust-policy](linuxfoundation.org/antitrust-policy). If you have questions about these matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer Updegrove LLP, which provides legal counsel to the Linux Foundation.
+
+## Voting Representative Attendance (_Alphabetical by 1st name_)
+### Premier Member Representatives
+* [ ] Brian Jarvis, Amazon Web Services Inc. [TAC Vice Chair]
+* [ ] Michael (Max)imilien, IBM [TAC Chair]
+* [ ] Norman Ashley, Cisco
+* [ ] Sophie Schmieg, Google
+* [ ] Yarkin Doroz, NVIDIA
+
+ ### Project Representatives
+* [ ] Nigel Jones, IBM [PQP]
+* [ ] Thomas Bailleux, SandboxAQ [OQS]
+
+## Non-Voting Representative Attendance
+### LF Staff 
+* [ ] Hart Montgomery
+* [ ] Ry Jones
+* [ ] Kenny Paul
+
+### Other Attendees
+* 
+
+## Agenda
+
+### Announcements
+<mark>_Put any announcements. Upcoming events, for example_
 </mark>
+* 
 
-# Presentation
+### Presentation
 <mark>_If there are any presentations from a WG, SIG, or project._
 </mark>
+* 
 
-# Decision
-<mark>_If there are any items up for vote (this is not meant to be exclusive but meant to highlight items that are expected to be voted on)_</mark>
+### Decision
+<mark>_If there are any items up for vote (this is not meant to be exclusive but meant to highlight items that are expected to be voted on)_
+</mark>
+* 
 
-# Discussion
+### Discussion
 <mark>_Items for discussion, including items left over from the previous meetings, as well as items that have been added_
 </mark>
+* 
 
-# Project Proposals 
+### Project Proposals 
 <mark>_include any project proposals that have been submitted and need discussion or decision._
 </mark>
+* 
 
-# Recordings
+## Action Items
+### Old
+* 
 
-* [Recordings are available on your Open Profile page](https://openprofile.dev/my-meetings) under Past Meetings
-
-# Upcoming TAC meetings
-
-[Please check the calendar](https://pqca.org/calendar/)
-
-# Attended by
-
-* [ ] Norman Ashley, Cisco
-* [ ] Michael (Max)imilien, IBM
-* [ ] Yarkin Doroz, NVIDIA
-* [ ] Sophie Schmieg, Google
-* [ ] Brian Jarvis, Amazon Web Services Inc.
-* [ ] Thomas Bailleux, SandboxAQ
-* [ ] Nigel Jones, IBM
+### New
+* 

--- a/meeting-minutes/2024/2024-08-14-TAC.md
+++ b/meeting-minutes/2024/2024-08-14-TAC.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: YYYY-MM-DD TAC Meeting Record
+parent: Meeting Minutes
+grand_parent: PQCA TAC
+---
+
+# Post-Quantum Cryptography Alliance - Technical Advisory Council (TAC) Meeting DD Month, 20YY
+* [Join the meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/98559442147?password=5e9d28b7-97d4-4628-9087-5f359dbf3d80)
+* Recordings are available on your [Open Profile page](https://openprofile.dev/my-meetings) under Past Meetings
+* [PQCA Meeting Calendar](https://pqca.org/calendar/)
+* [Discord Server](https://discord.gg/pqca)
+
+## Antitrust Policy Notice
+Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws.
+
+Examples of types of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation Antitrust Policy available at [linuxfoundation.org/antitrust-policy](linuxfoundation.org/antitrust-policy). If you have questions about these matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer Updegrove LLP, which provides legal counsel to the Linux Foundation.
+
+## Voting Representative Attendance (_Alphabetical by 1st name_)
+### Premier Member Representatives
+* [x ] Brian Jarvis, Amazon Web Services Inc. [TAC Vice Chair]
+* [x ] Michael (Max)imilien, IBM [TAC Chair]
+* [x ] Norman Ashley, Cisco
+* [ ] Sophie Schmieg, Google
+* [x ] Yarkin Doroz, NVIDIA
+
+ ### Project Representatives
+* [x ] Nigel Jones, IBM [PQP]
+* [ ] Thomas Bailleux, SandboxAQ [OQS]
+
+## Non-Voting Representative Attendance
+### LF Staff 
+* [x ] Hart Montgomery
+* [ ] Ry Jones
+* [x ] Kenny Paul
+
+### Other Attendees
+* Alex Bozarth
+* Bryan Uhri
+* Hugo Landau
+* Jason (US General Services Administration)
+* Sergio Sa
+
+## Agenda
+
+### Announcements
+* Introductions Kenny Paul, Andres Vega, Hugo Ladau
+
+### Lifecycle document -- voting process
+* if amendments are needed will be handled via PRs
+* (Andres) need a method to handle conceptual projects in order to form up.
+* (Max) Use a “community list” to foster discussions, would typically start as a workgroup and evolve from there 
+* ACTION kenny initiate e-vote for approval
+
+### Lifecycle document pending GH issues
+* A series of github issues opened in the TAC repo related to the doc. Discussion should occur here.
+* (Brian) some of the issues may be more appropriate for the individual project TSCs to resolve than the TAC.
+
+### Tooling working group
+* [#14](https://github.com/PQCA/TAC/issues/14) Likely to be a “go” need the lifecycle doc to be approved 1st.
+
+### Application / Industry working group
+* [#34](https://github.com/PQCA/TAC/issues/34) Could be best described a full stack for telco adoption - reference implementation basically
+* This would expand the scope of PQCA’s current focus
+* WG is really to discuss if doing that is something that we would want to pursue
+* (Nigel) reached out to some members of GSMA to understand what they may be working on related to this.
+* (Andres) is this a consortium, a company or what?  Need to verify if this is really just an openwash exercise.
+* Also need to clarify if this is a short term or long term WG.  “Industry” could be comprise a lot of perpetual work.
+
+### Non-production goals (Andres)
+* opened issue [#44](https://github.com/PQCA/TAC/issues/44) - would like to see the policy relaxed - as written it could be a deterrent to adoption
+* (Nigel) could be less black-and-white and more based on transparency and let the adopters decide - if it has been placed into production 
+* liboqs is already adopted by a number of organizations
+* (Hart) Agree w/ Nigel currently an OQS issue. We want to give users the tools to make well informed decisions .
+* ACTION Andres to work with Michael to get consensus
+
+### NIST doc
+* Have not planned to make a statement as an organization primarily due to other operational priorities.
+
+## Action Items
+### Old
+* none open
+
+### New
+* Lifecycle vote transitioned from Naomi to Kenny
+* Andres to work with Michael to get consensus on non-production goals


### PR DESCRIPTION
Revised based upon July 31, 2024 meeting minute format with additional modifications, such as re-ordering additional commonly referenced information near the top.