### PR TITLE
chore: add PR label action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+---
+meeting-minutes:
+  - changed-files:
+      - any-glob-to-any-file:
+          - meeting-minutes/**/*
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+- workflow_dispatch
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This change adds GitHub label automation to the repository by introducing two new files:

.github/labeler.yml

Configures rules for automatic labeling of pull requests.
Specifically, it sets up a rule:
If any files are changed in the meeting-minutes/**/* directory, the pull request will automatically get the label meeting-minutes.
.github/workflows/labeler.yml

Adds a GitHub Actions workflow to run the labeler.
The workflow triggers on:
pull_request_target (when a PR is opened, synchronized, or reopened, targeting the default branch)
workflow_dispatch (manual trigger)
The workflow checks out the repository code and runs the [actions/labeler](https://github.com/actions/labeler) action, which applies labels based on the rules in .github/labeler.yml.
Summary:
With these changes, pull requests that affect files in meeting-minutes/**/* will automatically be labeled meeting-minutes, helping to organize and track PRs related to meeting minutes.