### PR TITLE
Create blog-review-process.md

### DIFF
--- a/Processes/blog-review-process.md
+++ b/Processes/blog-review-process.md
@@ -18,29 +18,7 @@ All communication and collaboration occur via the **content-review@lists.pqca.or
 
 ### **Content Review Team Members**
 
-| Name | Company | PQCA Affiliation |
-| :---- | :---- | :---- |
-| Aditya Koranga | NgKore | TAC Vice Chair, Community Member |
-| anithapriyanatarajan@gmail.com | ? | ? |
-| Brian Jarvis | AWS | TAC Chair, Board Member |
-| Carlos Aguilar Melchor | SandboxAQ | Board Member, General Member Representative |
-| Hanno Becker | AWS | Premier Member |
-| Hart Montgomery | Linux Foundation | Head of PQCA |
-| Michael Maximilien | IBM | Premier Member |
-| Nigel Jones | IBM | Project Representative (PQCP) |
-| Prabhakar Pujeri | ? | ? |
-| Christina Harter | Linux Foundation | Program Manager |
-| Min Yu | Linux Foundation | Program Manager |
-
-
-If the blog content mentions a particular PQCA project, the TSC lead for that project will also be asked to review: 
-
-
-| Name | Company | PQCA Project |
-| :---- | :---- | :---- |
-| Douglas Stebila | University of Waterloo | OQS TSC Lead |
-| Matthias Kannwischer| Chelpis Quantum Tech | PQCP TSC Lead |
-| ? | ? | CBOMkit TSC Lead |
+View the list of current content review team members [here](https://docs.google.com/spreadsheets/d/1HF0Q8FkdjAAh2tHSrNnMZhu_oZRrkQcR_oRKZDCIgGY/edit?usp=sharing). 
 
 ---
 

--- a/Processes/blog-review-process.md
+++ b/Processes/blog-review-process.md
@@ -1,0 +1,86 @@
+## **PQCA Blog Content Review Process**
+
+### **Overview**
+
+The **PQCA Content Review Team** ensures that all blog submissions align with the alliance’s mission, maintain technical accuracy, and reflect the professionalism of the PQCA community.
+
+The team is composed of:
+
+* **Program Manager (PM):** Coordinates submissions, timelines, and publication.
+
+* **Technical Advisory Committee (TAC) representatives:** Validate technical content and accuracy, as well as ensure clarity and readability.
+
+* **Community representatives (as applicable):** Provide feedback from the broader PQC community perspective.
+
+All communication and collaboration occur via the **content-review@lists.pqca.org** mailing list.
+
+---
+
+### **Content Review Team Members**
+
+| Name | Company | PQCA Affiliation |
+| :---- | :---- | :---- |
+| Aditya Koranga | NgKore | TAC Vice Chair, Community Member |
+| anithapriyanatarajan@gmail.com | ? | ? |
+| Brian Jarvis | AWS | TAC Chair, Board Member |
+| Carlos Aguilar Melchor | SandboxAQ | Board Member, General Member Representative |
+| Hanno Becker | AWS | Premier Member |
+| Hart Montgomery | Linux Foundation | Head of PQCA |
+| Michael Maximilien | IBM | Premier Member |
+| Nigel Jones | IBM | Project Representative (PQCP) |
+| Prabhakar Pujeri | ? | ? |
+| Christina Harter | Linux Foundation | Program Manager |
+| Min Yu | Linux Foundation | Program Manager |
+
+---
+
+### **Step 1: Submission & Distribution**
+
+* When a blog post is submitted through the [PQCA Marketing Submission Form](https://form.asana.com/?k=CZt-jGD_z2Pi5Z_BJRX8_g&d=9283783873717), the **Program Manager (PM)** reviews it for completeness.
+
+* Within **1 business day**, the PM sends a Google Doc link to the **content-review@lists.pqca.org** mailing list for review.
+
+* The email will include the blog title, author, and proposed publication date.
+
+---
+
+### **Step 2: Content Review**
+
+* The **Content Review Team** has **1 week** from receipt of the submission email to review and provide feedback directly in the shared Google Doc.
+
+* Reviewers should focus on:
+
+  * Technical accuracy and clarity  
+  * Vendor neutrality and tone  
+  * Relevance to PQCA’s mission and community  
+  * Grammar, readability, and flow
+
+* Reviewers who provide feedback should **reply all** to the submission email to confirm their review.  
+* If no replies are received within one week, the blog will be considered **approved as-is** and scheduled for publication.
+
+---
+
+### **Step 3: Feedback to Author**
+
+* After the 1-week review period, the **Program Manager** consolidates all suggested edits and sends them back to the original author for **final review and approval**.
+
+* If **no changes** were requested, the Program Manager will notify the author and confirm the planned publication schedule.
+
+* By default, blogs are published at **9:00 AM PT on the next business day**, unless the author requests a different date or time. However, **PQCA staff may recommend an alternate publication schedule** to help **stagger posts and maximize visibility** across communication channels.
+
+---
+
+### **Step 4: Final Approval & Publication**
+
+* Once the author approves the final version, the **Program Manager** posts the blog to [**pqca.org/blog**](http://pqca.org/blog) and to the [PQCA LinkedIn page](https://www.linkedin.com/company/post-quantum-cryptography-alliance).
+  
+* The PM then shares the **final blog link** and corresponding **LinkedIn post** with the **Content Review Team** via email to confirm publication.
+
+* The published post will also be distributed to the **PQCA Outreach Committee mailing list** (outreach-committee@lists.pqca.org).
+
+---
+
+### **Step 5: Promotion & Amplification**
+
+* Content Review Team members are encouraged to share the published blog post on their **personal and organizational social channels** to help amplify community visibility and engagement.
+

--- a/Processes/blog-review-process.md
+++ b/Processes/blog-review-process.md
@@ -48,7 +48,7 @@ If the blog content mentions a particular PQCA project, the TSC lead for that pr
 
 * When a blog post is submitted through the [PQCA Marketing Submission Form](https://form.asana.com/?k=CZt-jGD_z2Pi5Z_BJRX8_g&d=9283783873717), the **Program Manager (PM)** reviews it for completeness.
 
-* Within **1 business day**, the PM sends a Google Doc link to the **content-review@lists.pqca.org** mailing list for review.
+* Within **1 business day**, the PM sends a Google Doc link to the **content-review@lists.pqca.org** mailing list, as well as the TSC lead of any project referenced in the blog content, for review.
 
 * The email will include the blog title, author, and proposed publication date.
 

--- a/Processes/blog-review-process.md
+++ b/Processes/blog-review-process.md
@@ -32,6 +32,16 @@ All communication and collaboration occur via the **content-review@lists.pqca.or
 | Christina Harter | Linux Foundation | Program Manager |
 | Min Yu | Linux Foundation | Program Manager |
 
+
+If the blog content mentions a particular PQCA project, the TSC lead for that project will also be asked to review: 
+
+
+| Name | Company | PQCA Project |
+| :---- | :---- | :---- |
+| Douglas Stebila | University of Waterloo | OQS TSC Lead |
+| Matthias Kannwischer| Chelpis Quantum Tech | PQCP TSC Lead |
+| ? | ? | CBOMkit TSC Lead |
+
 ---
 
 ### **Step 1: Submission & Distribution**


### PR DESCRIPTION
New blog review process for the content review team.

For reference, I've also added blog submission guidelines onto our wiki page for anyone who wants to submit a blog: https://github.com/PQCA/wiki/wiki/PQCA-Blog .